### PR TITLE
Don't change etc/hosts in entrypoint.

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -7,12 +7,5 @@ apachectl -f /etc/apache2/apache2.conf
 sleep 3
 tail -f /var/log/apache2/*&
 
-# Add a fqdn as an alias for the first non-127.0.0.1 ipv4 address to
-# /etc/hosts. This prevents sendmail from adding a 60 second delay on
-# startup while it tries to determine its hostname (see
-# http://selliott.org/node/40).
-cp /etc/hosts /etc/hosts.orig
-sed -e '/^127.0.0.1/! s/^\([0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+\)\t/\1\tmyhost.domain /' </etc/hosts.orig > /etc/hosts
-
 # Start our fake smtp server
 python -m smtpd -n -c DebuggingServer localhost:25


### PR DESCRIPTION
Writing files below /etc can trigger alerts in security products like
sysdig falco, so don't make any changes. Instead, we'll ensure that the
container name can be resolved.